### PR TITLE
Match Apple Weather: WeatherKit phase for selected date + accurate local fallback

### DIFF
--- a/DuneMoon/ContentView.swift
+++ b/DuneMoon/ContentView.swift
@@ -11,9 +11,25 @@ struct ContentView: View {
     @State private var selectedDate = Date()
     @State private var showCalendar = false
     @State private var showArrakisView = false
-    
+
+    @StateObject private var locationManager = LocationManager()
+    @StateObject private var weatherMoon = WeatherMoonService()
+    @State private var wkMoon: WeatherMoon?
+
+    // Local calculation, with WeatherKit's phase applied as a display override when
+    // available (so the main display matches Apple Weather). Illumination stays local.
     private var phaseData: MoonPhaseData {
-        MoonPhaseCalculator.calculatePhase(for: selectedDate)
+        let data = MoonPhaseCalculator.calculatePhase(for: selectedDate)
+        if let wk = wkMoon {
+            return data.applyingWeatherKit(wk)
+        }
+        return data
+    }
+
+    // Re-run the WeatherKit fetch whenever the date or resolved location changes.
+    private var moonTaskID: String {
+        let coord = locationManager.coordinate
+        return "\(selectedDate.timeIntervalSince1970)-\(coord.latitude)-\(coord.longitude)"
     }
     
     var body: some View {
@@ -84,7 +100,7 @@ struct ContentView: View {
                     
                     // Main moon phase display
                     VStack(spacing: 16) {
-                        Text(phaseData.emoji)
+                        Text(phaseData.displayEmoji)
                             .font(.system(size: 200))
                             .frame(width: 240, height: 240)
                             .shadow(color: Color.black.opacity(0.3), radius: 8, x: 2, y: 2)
@@ -95,7 +111,7 @@ struct ContentView: View {
                         HStack(spacing: 30) {
                             StatBadge(
                                 label: "Phase",
-                                value: phaseData.phaseName,
+                                value: phaseData.displayName,
                                 icon: "moon.stars.fill"
                             )
                             .id("\(selectedDate)-phase")
@@ -204,6 +220,14 @@ struct ContentView: View {
             }
             .fullScreenCover(isPresented: $showArrakisView) {
                 ArrakisMoonView(phaseData: phaseData)
+            }
+            .onAppear {
+                locationManager.requestLocation()
+            }
+            .task(id: moonTaskID) {
+                // When this returns nil (offline / out of range / not entitled), the
+                // display falls back to the local calculation.
+                wkMoon = await weatherMoon.moon(for: selectedDate, at: locationManager.coordinate)
             }
         }
     }

--- a/DuneMoon/DuneMoon/ArrakisMoonView.swift
+++ b/DuneMoon/DuneMoon/ArrakisMoonView.swift
@@ -25,7 +25,7 @@ struct ArrakisMoonView: View {
                 // Overlay the dynamic moon emoji to completely cover the illustrated moon
                 VStack {
                     HStack {
-                        Text(phaseData.emoji)
+                        Text(phaseData.displayEmoji)
                             .font(.system(size: 200))
                             .shadow(color: Color.black.opacity(0.3), radius: 8, x: 2, y: 2)
                             .padding(.leading, 8)
@@ -47,7 +47,7 @@ struct ArrakisMoonView: View {
                             .kerning(6)
                             .padding(.top, 16)
                         
-                        Text(phaseData.phaseName.uppercased())
+                        Text(phaseData.displayName.uppercased())
                             .font(.system(size: 14, weight: .bold, design: .serif))
                             .foregroundColor(Color(red: 0.40, green: 0.32, blue: 0.25))
                             .kerning(3)
@@ -74,7 +74,7 @@ struct ArrakisMoonView: View {
                                 .frame(width: 2, height: 50)
                             
                             VStack(spacing: 4) {
-                                Text(phaseData.phaseName.uppercased())
+                                Text(phaseData.displayName.uppercased())
                                     .font(.system(size: 20, weight: .black, design: .serif))
                                     .foregroundColor(Color(red: 0.25, green: 0.20, blue: 0.15))
                                     .multilineTextAlignment(.center)

--- a/DuneMoon/DuneMoon/PhaseInfoPanel.swift
+++ b/DuneMoon/DuneMoon/PhaseInfoPanel.swift
@@ -13,17 +13,35 @@ struct PhaseInfoPanel: View {
     @StateObject private var locationManager = LocationManager()
     @StateObject private var weatherMoon = WeatherMoonService()
 
-    // Seeded with the local calculation; upgraded to WeatherKit values when available.
-    @State private var moonTimes: (rise: Date?, set: Date?) = (nil, nil)
-    // True once WeatherKit moonrise/moonset have replaced the local seed.
-    @State private var usingWeatherKit = false
+    // WeatherKit moon data for the selected date, when available.
+    @State private var wkMoon: WeatherMoon?
 
+    // Local calculation, with WeatherKit's phase applied as a display override when
+    // available (so the shown phase matches Apple Weather). Illumination and the
+    // next-phase countdown remain local, since WeatherKit does not provide them.
     private var phaseData: MoonPhaseData {
-        MoonPhaseCalculator.calculatePhase(for: date)
+        let data = MoonPhaseCalculator.calculatePhase(for: date)
+        if let wk = wkMoon {
+            return data.applyingWeatherKit(wk)
+        }
+        return data
+    }
+
+    // Moonrise/moonset: WeatherKit when available, otherwise the local calculation.
+    private var moonTimes: (rise: Date?, set: Date?) {
+        if let wk = wkMoon {
+            return (wk.rise, wk.set)
+        }
+        let coord = locationManager.coordinate
+        return MoonPhaseCalculator.calculateMoonTimes(
+            for: date,
+            latitude: coord.latitude,
+            longitude: coord.longitude
+        )
     }
 
     // Re-run the WeatherKit fetch whenever the date or resolved location changes.
-    private var moonTimesTaskID: String {
+    private var moonTaskID: String {
         let coord = locationManager.coordinate
         return "\(date.timeIntervalSince1970)-\(coord.latitude)-\(coord.longitude)"
     }
@@ -32,7 +50,7 @@ struct PhaseInfoPanel: View {
         VStack(spacing: 20) {
             // Phase name and illumination
             VStack(spacing: 8) {
-                Text(phaseData.phaseName)
+                Text(phaseData.displayName)
                     .font(.system(size: 28, weight: .bold, design: .serif))
                     .foregroundStyle(
                         LinearGradient(
@@ -45,10 +63,10 @@ struct PhaseInfoPanel: View {
                     .kerning(3)
                 
                 HStack(spacing: 4) {
-                    Image(systemName: phaseData.isWaxing ? "arrow.up.circle.fill" : "arrow.down.circle.fill")
-                        .foregroundColor(phaseData.isWaxing ? duneBlue : duneOrange)
-                    
-                    Text(phaseData.isWaxing ? "Waxing" : "Waning")
+                    Image(systemName: phaseData.displayIsWaxing ? "arrow.up.circle.fill" : "arrow.down.circle.fill")
+                        .foregroundColor(phaseData.displayIsWaxing ? duneBlue : duneOrange)
+
+                    Text(phaseData.displayIsWaxing ? "Waxing" : "Waning")
                         .font(.system(size: 14, weight: .medium, design: .rounded))
                         .foregroundColor(duneSand.opacity(0.8))
                 }
@@ -123,7 +141,7 @@ struct PhaseInfoPanel: View {
             }
 
             // Apple Weather attribution — required whenever WeatherKit data is shown.
-            if usingWeatherKit, let attribution = weatherMoon.attribution {
+            if wkMoon != nil, let attribution = weatherMoon.attribution {
                 WeatherAttributionView(attribution: attribution)
             }
 
@@ -174,23 +192,10 @@ struct PhaseInfoPanel: View {
         .onAppear {
             locationManager.requestLocation()
         }
-        .task(id: moonTimesTaskID) {
-            let coord = locationManager.coordinate
-
-            // Seed immediately with the local calculation so the cards are never blank
-            // while loading, offline, or for dates outside WeatherKit's window.
-            moonTimes = MoonPhaseCalculator.calculateMoonTimes(
-                for: date,
-                latitude: coord.latitude,
-                longitude: coord.longitude
-            )
-            usingWeatherKit = false
-
-            // Upgrade to WeatherKit's location-accurate times when available.
-            if let weatherTimes = await weatherMoon.moonTimes(for: date, at: coord) {
-                moonTimes = weatherTimes
-                usingWeatherKit = true
-            }
+        .task(id: moonTaskID) {
+            // Until this resolves (and when it returns nil), phaseData and moonTimes fall
+            // back to the local calculation, so the panel is never blank.
+            wkMoon = await weatherMoon.moon(for: date, at: locationManager.coordinate)
         }
     }
     

--- a/DuneMoon/DuneMoon/WeatherMoonService.swift
+++ b/DuneMoon/DuneMoon/WeatherMoonService.swift
@@ -2,8 +2,8 @@
 //  WeatherMoonService.swift
 //  DuneMoon
 //
-//  Provides accurate, location-specific moonrise/moonset times via WeatherKit,
-//  with the local MoonPhaseCalculator used as a fallback by callers.
+//  Provides accurate, location-specific moon data (phase + moonrise/moonset) via
+//  WeatherKit, with the local MoonPhaseCalculator used as a fallback by callers.
 //
 
 import Foundation
@@ -14,7 +14,40 @@ import os
 
 private let weatherLog = Logger(subsystem: "AlienArchitecture.DuneMoon", category: "WeatherKit")
 
-/// Fetches moonrise/moonset for a given date and location from WeatherKit.
+/// A snapshot of WeatherKit's moon data for a single day and location. The phase fields
+/// match what Apple Weather shows, since both come from the same WeatherKit `MoonPhase`.
+struct WeatherMoon {
+    let rise: Date?
+    let set: Date?
+    let phaseName: String
+    let phaseEmoji: String
+    let isWaxing: Bool
+    /// True when WeatherKit's daily label is New or Full. These are whole-day "instant"
+    /// labels: WeatherKit calls the entire new-moon day "New Moon", whereas the
+    /// instantaneous phase (what Apple Weather's headline shows) is already a crescent
+    /// once past the exact instant. Callers refine these using the local calculation.
+    let isNewOrFull: Bool
+}
+
+extension MoonPhaseData {
+    /// Applies WeatherKit's phase as a display override so the shown phase matches Apple
+    /// Weather. For WeatherKit's whole-day New/Full labels, the instantaneous local
+    /// classification is kept instead, so a new-moon day past the exact instant reads as
+    /// a crescent (matching Apple Weather's live headline) rather than "New Moon" all day.
+    func applyingWeatherKit(_ wk: WeatherMoon) -> MoonPhaseData {
+        guard !wk.isNewOrFull else {
+            // Keep the time-accurate local phase for the boundary instant.
+            return self
+        }
+        var copy = self
+        copy.phaseNameOverride = wk.phaseName
+        copy.emojiOverride = wk.phaseEmoji
+        copy.isWaxingOverride = wk.isWaxing
+        return copy
+    }
+}
+
+/// Fetches moon phase and moonrise/moonset for a given date and location from WeatherKit.
 ///
 /// WeatherKit only covers a limited window around the present (its daily forecast is
 /// ~10 contiguous days from today), is asynchronous, and requires network access plus
@@ -24,8 +57,8 @@ private let weatherLog = Logger(subsystem: "AlienArchitecture.DuneMoon", categor
 final class WeatherMoonService: ObservableObject {
     private let service = WeatherService.shared
 
-    /// Cache of resolved times keyed by rounded coordinate + day, to avoid refetching.
-    private var cache: [Key: (rise: Date?, set: Date?)] = [:]
+    /// Cache of resolved moon data keyed by rounded coordinate + day, to avoid refetching.
+    private var cache: [Key: WeatherMoon] = [:]
 
     /// The required Apple Weather attribution, loaded lazily the first time WeatherKit
     /// data is successfully shown. `nil` until then.
@@ -37,12 +70,12 @@ final class WeatherMoonService: ObservableObject {
         let day: Date
     }
 
-    /// Returns moonrise/moonset for `date` at `coordinate`, or `nil` if WeatherKit can't
-    /// supply it (offline, out of range, or not entitled). Results are cached.
-    func moonTimes(
+    /// Returns moon data for `date` at `coordinate`, or `nil` if WeatherKit can't supply
+    /// it (offline, out of range, or not entitled). Results are cached.
+    func moon(
         for date: Date,
         at coordinate: CLLocationCoordinate2D
-    ) async -> (rise: Date?, set: Date?)? {
+    ) async -> WeatherMoon? {
         let calendar = Calendar.current
         let day = calendar.startOfDay(for: date)
 
@@ -67,9 +100,16 @@ final class WeatherMoonService: ObservableObject {
                 return nil // Requested day is outside WeatherKit's forecast window.
             }
 
-            let result = (rise: match.moon.moonrise, set: match.moon.moonset)
+            let result = WeatherMoon(
+                rise: match.moon.moonrise,
+                set: match.moon.moonset,
+                phaseName: match.moon.phase.displayName,
+                phaseEmoji: match.moon.phase.emoji,
+                isWaxing: match.moon.phase.isWaxing,
+                isNewOrFull: match.moon.phase == .new || match.moon.phase == .full
+            )
             cache[key] = result
-            weatherLog.debug("WeatherKit moon times: rise \(String(describing: result.rise), privacy: .public), set \(String(describing: result.set), privacy: .public)")
+            weatherLog.debug("WeatherKit moon: phase \(result.phaseName, privacy: .public), rise \(String(describing: result.rise), privacy: .public), set \(String(describing: result.set), privacy: .public)")
 
             // Attribution is mandatory whenever Apple Weather data is displayed.
             if attribution == nil {
@@ -84,6 +124,45 @@ final class WeatherMoonService: ObservableObject {
         } catch {
             weatherLog.error("WeatherKit request failed: \(error.localizedDescription, privacy: .public) — full: \(String(describing: error), privacy: .public)")
             return nil
+        }
+    }
+}
+
+/// Maps WeatherKit's `MoonPhase` enum to the app's display strings. These names and
+/// emoji match Apple Weather, since they describe the same 8 WeatherKit phases.
+private extension MoonPhase {
+    var displayName: String {
+        switch self {
+        case .new:            return "New Moon"
+        case .waxingCrescent: return "Waxing Crescent"
+        case .firstQuarter:   return "First Quarter"
+        case .waxingGibbous:  return "Waxing Gibbous"
+        case .full:           return "Full Moon"
+        case .waningGibbous:  return "Waning Gibbous"
+        case .lastQuarter:    return "Last Quarter"
+        case .waningCrescent: return "Waning Crescent"
+        @unknown default:     return "Unknown"
+        }
+    }
+
+    var emoji: String {
+        switch self {
+        case .new:            return "🌑"
+        case .waxingCrescent: return "🌒"
+        case .firstQuarter:   return "🌓"
+        case .waxingGibbous:  return "🌔"
+        case .full:           return "🌕"
+        case .waningGibbous:  return "🌖"
+        case .lastQuarter:    return "🌗"
+        case .waningCrescent: return "🌘"
+        @unknown default:     return "🌑"
+        }
+    }
+
+    var isWaxing: Bool {
+        switch self {
+        case .new, .waxingCrescent, .firstQuarter, .waxingGibbous: return true
+        default: return false
         }
     }
 }

--- a/DuneMoon/MoonPhaseCalculator.swift
+++ b/DuneMoon/MoonPhaseCalculator.swift
@@ -104,16 +104,18 @@ class MoonPhaseCalculator {
     }
 
     private static func calculateNextPhase(currentPhase: Double) -> (Int, String) {
+        // Thresholds are the end boundary of each phase (matching classify()),
+        // paired with the name of the phase that starts at that boundary.
         let phases: [(threshold: Double, name: String)] = [
-            (0.033, "New Moon"),
-            (0.216, "Waxing Crescent"),
-            (0.283, "First Quarter"),
-            (0.466, "Waxing Gibbous"),
-            (0.533, "Full Moon"),
-            (0.716, "Waning Gibbous"),
-            (0.783, "Last Quarter"),
-            (0.967, "Waning Crescent"),
-            (1.033, "New Moon")
+            (0.02, "Waxing Crescent"),
+            (0.23, "First Quarter"),
+            (0.27, "Waxing Gibbous"),
+            (0.48, "Full Moon"),
+            (0.52, "Waning Gibbous"),
+            (0.73, "Last Quarter"),
+            (0.77, "Waning Crescent"),
+            (0.98, "New Moon"),
+            (1.02, "Waxing Crescent")
         ]
         
         for phase in phases {

--- a/DuneMoon/MoonPhaseCalculator.swift
+++ b/DuneMoon/MoonPhaseCalculator.swift
@@ -16,49 +16,42 @@ struct MoonPhaseData {
     let daysToNextPhase: Int
     let nextPhaseName: String
 
-    // Moon phase emoji corresponding to the current phase value
-    var emoji: String {
-        switch phase {
-        case ..<0.05, 0.95...: return "🌑" // New Moon
-        case ..<0.20:          return "🌒" // Waxing Crescent
-        case ..<0.30:          return "🌓" // First Quarter
-        case ..<0.45:          return "🌔" // Waxing Gibbous
-        case ..<0.55:          return "🌕" // Full Moon
-        case ..<0.70:          return "🌖" // Waning Gibbous
-        case ..<0.80:          return "🌗" // Last Quarter
-        default:               return "🌘" // Waning Crescent
-        }
-    }
+    // Optional display overrides sourced from WeatherKit for the selected date, so the
+    // shown phase matches Apple Weather. When nil, the locally computed values are used.
+    var phaseNameOverride: String? = nil
+    var emojiOverride: String? = nil
+    var isWaxingOverride: Bool? = nil
+
+    // Locally computed emoji for the continuous phase value.
+    var emoji: String { MoonPhaseCalculator.classify(phase: phase).emoji }
+
+    // Values to display: the WeatherKit override when present, otherwise the local value.
+    var displayName: String { phaseNameOverride ?? phaseName }
+    var displayEmoji: String { emojiOverride ?? emoji }
+    var displayIsWaxing: Bool { isWaxingOverride ?? isWaxing }
 }
 
 class MoonPhaseCalculator {
     
     // Calculate moon phase for a given date
     static func calculatePhase(for date: Date) -> MoonPhaseData {
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day], from: date)
-        
-        // Julian date calculation
-        let year = components.year!
-        let month = components.month!
-        let day = components.day!
-        
-        let julianDate = calculateJulianDate(year: year, month: month, day: day)
-        
-        // Known new moon: January 6, 2000
-        let knownNewMoon = 2451550.1
+        // Precise Julian Date (UT), including the time of day so the phase is accurate
+        // right at the new/full boundaries (rather than snapping to midnight).
+        let julianDate = date.timeIntervalSince1970 / 86400.0 + 2440587.5
+
+        // Known new moon: January 6, 2000, 18:14 UTC (JD 2451550.26).
+        let knownNewMoon = 2451550.26
         let synodicMonth = 29.53058867 // Average lunar cycle
-        
-        let daysSinceNewMoon = julianDate - knownNewMoon
-        let newMoons = daysSinceNewMoon / synodicMonth
-        let phase = newMoons - floor(newMoons)
-        
+
+        var phase = (julianDate - knownNewMoon) / synodicMonth
+        phase -= floor(phase) // Fractional position in the cycle, 0.0..<1.0
+
         let illumination = calculateIllumination(phase: phase)
         let isWaxing = phase < 0.5
-        let phaseName = getPhaseName(phase: phase)
-        
+        let phaseName = classify(phase: phase).name
+
         let (daysToNext, nextName) = calculateNextPhase(currentPhase: phase)
-        
+
         return MoonPhaseData(
             phase: phase,
             illumination: illumination,
@@ -67,6 +60,22 @@ class MoonPhaseCalculator {
             daysToNextPhase: daysToNext,
             nextPhaseName: nextName
         )
+    }
+
+    // Classify a continuous phase value (0.0..<1.0) into a phase name and emoji.
+    // Boundaries follow Apple Weather's convention: New/Full/Quarter occupy narrow
+    // windows around their exact instants, with crescent/gibbous covering the rest.
+    static func classify(phase: Double) -> (name: String, emoji: String) {
+        switch phase {
+        case ..<0.02, 0.98...: return ("New Moon", "🌑")
+        case ..<0.23:          return ("Waxing Crescent", "🌒")
+        case ..<0.27:          return ("First Quarter", "🌓")
+        case ..<0.48:          return ("Waxing Gibbous", "🌔")
+        case ..<0.52:          return ("Full Moon", "🌕")
+        case ..<0.73:          return ("Waning Gibbous", "🌖")
+        case ..<0.77:          return ("Last Quarter", "🌗")
+        default:               return ("Waning Crescent", "🌘")
+        }
     }
     
     private static func calculateJulianDate(year: Int, month: Int, day: Int) -> Double {
@@ -89,28 +98,11 @@ class MoonPhaseCalculator {
     }
     
     private static func calculateIllumination(phase: Double) -> Double {
-        // Convert phase to illumination percentage
-        if phase < 0.5 {
-            return phase * 200.0
-        } else {
-            return (1.0 - phase) * 200.0
-        }
+        // Fraction of the disc lit, from the phase angle: (1 - cos θ) / 2.
+        let phaseAngle = phase * 2.0 * Double.pi
+        return (1.0 - cos(phaseAngle)) / 2.0 * 100.0
     }
-    
-    private static func getPhaseName(phase: Double) -> String {
-        switch phase {
-        case 0..<0.033: return "New Moon"
-        case 0.033..<0.216: return "Waxing Crescent"
-        case 0.216..<0.283: return "First Quarter"
-        case 0.283..<0.466: return "Waxing Gibbous"
-        case 0.466..<0.533: return "Full Moon"
-        case 0.533..<0.716: return "Waning Gibbous"
-        case 0.716..<0.783: return "Last Quarter"
-        case 0.783..<0.967: return "Waning Crescent"
-        default: return "New Moon"
-        }
-    }
-    
+
     private static func calculateNextPhase(currentPhase: Double) -> (Int, String) {
         let phases: [(threshold: Double, name: String)] = [
             (0.033, "New Moon"),

--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ A beautiful iOS app that tracks lunar phases with a stunning Dune/Arrakis-inspir
 - Smooth animations and intuitive gesture controls
 
 ### 🌑 Accurate Moon Phase Calculations
-- Real-time moon phase visualization with custom-drawn graphics
-- Precise illumination percentage calculations
+- Moon phase shown as a Unicode emoji that matches Apple Weather: for the selected date
+  the phase comes from **WeatherKit** when available, with a precise local calculation
+  as the fallback (and for the calendar/timeline dates)
+- Local phase computed at the exact instant (not snapped to midnight) so it is correct
+  right at the new/full boundaries
+- Precise illumination percentage (cosine of the phase angle)
 - Phase names (New Moon, Waxing Crescent, First Quarter, Waxing Gibbous, Full Moon, Waning Gibbous, Last Quarter, Waning Crescent)
 - Days until next major phase
 - Waxing/waning status indication

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -33,7 +33,7 @@ Each file has a single, well-defined responsibility:
 | `DuneMoonApp.swift` | App lifecycle and entry point |
 | `ContentView.swift` | Main UI composition and state coordination |
 | `MoonPhaseCalculator.swift` | All astronomical calculations (phase data + fallback moonrise/moonset) |
-| `WeatherMoonService.swift` | WeatherKit moonrise/moonset fetching, caching, and attribution |
+| `WeatherMoonService.swift` | WeatherKit moon phase + moonrise/moonset fetching, caching, and attribution |
 | `LocationManager.swift` | GPS and location services |
 | `TimelineView.swift` | Date selection and navigation |
 | `PhaseInfoPanel.swift` | Information display |
@@ -200,19 +200,20 @@ LocationManager
 
 ### WeatherMoonService (Observable Object, @MainActor)
 
-Primary source for moonrise/moonset via Apple WeatherKit, with the local
-`MoonPhaseCalculator.calculateMoonTimes` used as a fallback in `PhaseInfoPanel`.
+Primary source for the selected date's moon phase and moonrise/moonset via Apple
+WeatherKit, with the local `MoonPhaseCalculator` used as a fallback.
 
 ```
 WeatherMoonService
-├── moonTimes(for:at:) async → (rise: Date?, set: Date?)?   // nil ⇒ caller falls back
-├── @Published attribution: WeatherAttribution?              // required Apple Weather mark
-└── cache: [coordinate+day → times]
+├── moon(for:at:) async → WeatherMoon?              // phase + rise/set; nil ⇒ fall back
+├── @Published attribution: WeatherAttribution?     // required Apple Weather mark
+└── cache: [coordinate+day → WeatherMoon]
 ```
 
-`PhaseInfoPanel` seeds the cards with the local calculation, then upgrades to
-WeatherKit values inside a `.task` when available. See
-[WeatherKit Integration](WeatherKit.md) for the full data flow and requirements.
+`ContentView` and `PhaseInfoPanel` apply WeatherKit's phase to the selected date via
+`MoonPhaseData.applyingWeatherKit(_:)`, which keeps the instantaneous local phase on
+WeatherKit's whole-day New/Full labels (so a new-moon day reads as a crescent, matching
+Apple Weather). See [WeatherKit Integration](WeatherKit.md) for the full data flow.
 
 ## Memory Management
 

--- a/docs/MoonPhaseCalculation.md
+++ b/docs/MoonPhaseCalculation.md
@@ -54,6 +54,12 @@ let daysSinceNewMoon = daysBetween(from: referenceNewMoon, to: targetDate)
 let phase = (daysSinceNewMoon.truncatingRemainder(dividingBy: synodicMonth)) / synodicMonth
 ```
 
+> **Implementation note:** The code derives the Julian Date directly from the date's
+> timestamp — `date.timeIntervalSince1970 / 86400 + 2440587.5` — so the phase includes
+> the **time of day** rather than snapping to midnight. This keeps the phase correct
+> right at the new/full boundaries (e.g. a few hours after a new moon already reads as a
+> thin waxing crescent). The reference new moon is JD 2451550.26 (2000-01-06 18:14 UTC).
+
 **Phase Values:**
 - `0.0` = New Moon
 - `0.25` = First Quarter
@@ -98,29 +104,27 @@ Illumination (%) = [(1 - cos(θ)) / 2] × 100
 
 ## Phase Names
 
-Phase names are determined by phase value ranges:
+> **Note:** For the **selected date**, the displayed phase name/emoji come from
+> **WeatherKit** when available (matching Apple Weather) — see
+> [WeatherKit Integration](WeatherKit.md). The local classification below is the
+> fallback (offline / not entitled) and is what the calendar grid and timeline use.
+
+A single `classify(phase:)` function maps the continuous phase value to both a name and
+an emoji (keeping the two in sync). Boundaries follow Apple Weather's convention:
+New / Full / Quarter occupy narrow windows (~1 day) around their exact instants, with
+crescent and gibbous covering the spans between them.
 
 ```swift
-func calculatePhaseName(phase: Double) -> String {
+static func classify(phase: Double) -> (name: String, emoji: String) {
     switch phase {
-    case 0..<0.03, 0.97..<1.0:
-        return "New Moon"
-    case 0.03..<0.22:
-        return "Waxing Crescent"
-    case 0.22..<0.28:
-        return "First Quarter"
-    case 0.28..<0.47:
-        return "Waxing Gibbous"
-    case 0.47..<0.53:
-        return "Full Moon"
-    case 0.53..<0.72:
-        return "Waning Gibbous"
-    case 0.72..<0.78:
-        return "Last Quarter"
-    case 0.78..<0.97:
-        return "Waning Crescent"
-    default:
-        return "Unknown"
+    case ..<0.02, 0.98...: return ("New Moon", "🌑")
+    case ..<0.23:          return ("Waxing Crescent", "🌒")
+    case ..<0.27:          return ("First Quarter", "🌓")
+    case ..<0.48:          return ("Waxing Gibbous", "🌔")
+    case ..<0.52:          return ("Full Moon", "🌕")
+    case ..<0.73:          return ("Waning Gibbous", "🌖")
+    case ..<0.77:          return ("Last Quarter", "🌗")
+    default:               return ("Waning Crescent", "🌘")
     }
 }
 ```
@@ -130,15 +134,15 @@ func calculatePhaseName(phase: Double) -> String {
 ```
 Phase Range         Name
 ───────────────────────────────
-0.00 - 0.03         New Moon
-0.03 - 0.22         Waxing Crescent
-0.22 - 0.28         First Quarter
-0.28 - 0.47         Waxing Gibbous
-0.47 - 0.53         Full Moon
-0.53 - 0.72         Waning Gibbous
-0.72 - 0.78         Last Quarter
-0.78 - 0.97         Waning Crescent
-0.97 - 1.00         New Moon
+0.00 - 0.02         New Moon
+0.02 - 0.23         Waxing Crescent
+0.23 - 0.27         First Quarter
+0.27 - 0.48         Waxing Gibbous
+0.48 - 0.52         Full Moon
+0.52 - 0.73         Waning Gibbous
+0.73 - 0.77         Last Quarter
+0.77 - 0.98         Waning Crescent
+0.98 - 1.00         New Moon
 ```
 
 ## Waxing vs Waning

--- a/docs/WeatherKit.md
+++ b/docs/WeatherKit.md
@@ -1,8 +1,8 @@
 ---
 title: "WeatherKit Integration"
-description: "How Dune Moon uses Apple WeatherKit for moonrise/moonset times, including the local fallback, requirements, and attribution"
+description: "How Dune Moon uses Apple WeatherKit for the moon phase and moonrise/moonset, including the New/Full refinement, local fallback, requirements, and attribution"
 category: "technical-reference"
-version: "1.1.0"
+version: "1.2.0"
 last_updated: "2026-06-15"
 tags: ["weatherkit", "moonrise", "moonset", "location", "ios", "fallback"]
 audience: "developers"
@@ -13,31 +13,37 @@ platform: "iOS 17.0+"
 
 ## Overview
 
-Dune Moon uses Apple's **WeatherKit** framework as the primary source for
-**moonrise and moonset times**. WeatherKit returns location-accurate lunar event
-times computed by Apple's weather service, which are more accurate than the app's
-own approximate astronomical calculation.
+Dune Moon uses Apple's **WeatherKit** framework as the primary source for the
+**moon phase and moonrise/moonset times of the selected date**. WeatherKit returns
+location-accurate lunar data computed by Apple's weather service — the same data the
+Apple Weather app shows — which is more accurate than the app's own approximate
+astronomical calculation.
 
-WeatherKit is used **only** for moonrise/moonset. Everything else — the moon phase
-value, illumination percentage, phase name, emoji, waxing/waning status, and the
-"days to next phase" countdown — continues to come from the local
-[`MoonPhaseCalculator`](MoonPhaseCalculation.md), which is instant, works offline,
-and works for any date.
+For the **selected date**, WeatherKit provides the phase name and emoji (so they match
+Apple Weather) plus moonrise/moonset. The local
+[`MoonPhaseCalculator`](MoonPhaseCalculation.md) supplies everything WeatherKit does
+not — the illumination percentage and the "days to next phase" countdown — and serves
+as the **fallback** for the phase and rise/set whenever WeatherKit is unavailable
+(offline, not entitled, or for dates outside its forecast window). The calendar grid
+and timeline (which show many dates, mostly outside WeatherKit's ~10-day window) always
+use the local calculation.
 
 > **Why a hybrid?** WeatherKit's moon data is limited: it exposes only `moonrise`,
 > `moonset`, and an 8-value `MoonPhase` enum (no continuous phase fraction and no
 > illumination percentage), its daily forecast only covers roughly 10 days from the
 > current day, and it requires network access plus an entitlement. The local
-> calculator covers any date offline. Combining them keeps the app's strengths while
-> upgrading the one metric WeatherKit does better.
+> calculator covers any date offline and supplies illumination. Combining them keeps
+> the app's strengths while matching Apple Weather for the selected date.
 
 ## What WeatherKit provides
 
 | Data | Source | Notes |
 |------|--------|-------|
+| Phase name + emoji (selected date) | `MoonEvents.phase` (`MoonPhase` enum) | Matches Apple Weather; falls back to local |
 | Moonrise time | `MoonEvents.moonrise` | `Date?` — may be `nil` on days with no moonrise |
 | Moonset time | `MoonEvents.moonset` | `Date?` — may be `nil` on days with no moonset |
-| Moon phase, illumination, phase name, emoji, next phase | `MoonPhaseCalculator` (local) | Not sourced from WeatherKit |
+| Illumination %, days-to-next-phase | `MoonPhaseCalculator` (local) | Not provided by WeatherKit |
+| Phase for calendar/timeline dates | `MoonPhaseCalculator` (local) | Mostly outside WeatherKit's window |
 
 ## How it works
 
@@ -45,68 +51,76 @@ and works for any date.
 
 `WeatherMoonService` is a `@MainActor` `ObservableObject` that wraps the shared
 `WeatherService`. It fetches the daily forecast for a coordinate, finds the
-`DayWeather` matching the requested day, and returns its moonrise/moonset. Results
-are cached by rounded coordinate and day. Any failure (offline, out of forecast
-range, or not entitled) returns `nil` so the caller can fall back.
+`DayWeather` matching the requested day, and returns a `WeatherMoon` snapshot (phase
+name/emoji, waxing flag, moonrise/moonset). Results are cached by rounded coordinate
+and day. Any failure (offline, out of forecast range, or not entitled) returns `nil`
+so the caller can fall back to the local calculation.
 
 ```swift
-import WeatherKit
-import CoreLocation
+let forecast = try await service.weather(for: location, including: .daily) // ~10 days
+guard let match = forecast.first(where: {
+    calendar.isDate($0.date, inSameDayAs: day)
+}) else { return nil } // Requested day is outside WeatherKit's forecast window.
 
-@MainActor
-final class WeatherMoonService: ObservableObject {
-    private let service = WeatherService.shared
+return WeatherMoon(
+    rise: match.moon.moonrise,
+    set: match.moon.moonset,
+    phaseName: match.moon.phase.displayName,   // e.g. "Waxing Crescent"
+    phaseEmoji: match.moon.phase.emoji,        // e.g. "🌒"
+    isWaxing: match.moon.phase.isWaxing,
+    // New/Full are whole-day labels; flagged so callers can refine them (see below).
+    isNewOrFull: match.moon.phase == .new || match.moon.phase == .full
+)
+```
 
-    /// Returns moonrise/moonset for `date` at `coordinate`, or `nil` if WeatherKit
-    /// can't supply it. Results are cached.
-    func moonTimes(
-        for date: Date,
-        at coordinate: CLLocationCoordinate2D
-    ) async -> (rise: Date?, set: Date?)? {
-        let calendar = Calendar.current
-        let day = calendar.startOfDay(for: date)
-        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
-        do {
-            // `.daily` returns ~10 contiguous days starting today.
-            let forecast = try await service.weather(for: location, including: .daily)
-            guard let match = forecast.first(where: {
-                calendar.isDate($0.date, inSameDayAs: day)
-            }) else {
-                return nil // Requested day is outside WeatherKit's forecast window.
-            }
-            return (rise: match.moon.moonrise, set: match.moon.moonset)
-        } catch {
-            return nil // Offline or not entitled — caller falls back to the local calc.
+### Daily vs. instantaneous phase (the New/Full refinement)
+
+WeatherKit's `MoonPhase` is a **per-day** label: it calls the *entire* new-moon day
+"New Moon", even though the instantaneous phase is already a thin **waxing crescent**
+a few hours after the exact instant — which is what Apple Weather's *headline* shows.
+To match that headline, `applyingWeatherKit(_:)` uses WeatherKit's label for every
+phase **except** New/Full, where it keeps the time-accurate local classification:
+
+```swift
+extension MoonPhaseData {
+    func applyingWeatherKit(_ wk: WeatherMoon) -> MoonPhaseData {
+        guard !wk.isNewOrFull else {
+            return self // Keep the instantaneous local phase for the New/Full instant.
         }
+        var copy = self
+        copy.phaseNameOverride = wk.phaseName
+        copy.emojiOverride = wk.phaseEmoji
+        copy.isWaxingOverride = wk.isWaxing
+        return copy
     }
 }
 ```
 
-### View layer: `PhaseInfoPanel` with local fallback
+So a new-moon day reads as "Waxing Crescent" once past the instant (matching Apple
+Weather), while crescent/gibbous/quarter days use WeatherKit's authoritative label.
 
-`PhaseInfoPanel` seeds the moonrise/moonset cards **immediately** with the local
-calculation so they are never blank, then upgrades to WeatherKit values inside a
-`.task` when they are available. The task re-runs when the selected date or the
-resolved location changes.
+### View layer
+
+`ContentView` (main display + Arrakis view) and `PhaseInfoPanel` each compute the
+local phase, then apply the WeatherKit override for the selected date inside a `.task`:
 
 ```swift
-// Seed with the local calculation (instant, offline, any date).
-moonTimes = MoonPhaseCalculator.calculateMoonTimes(
-    for: date,
-    latitude: coordinate.latitude,
-    longitude: coordinate.longitude
-)
-
-// Upgrade to WeatherKit's location-accurate times when available.
-if let weatherTimes = await weatherMoon.moonTimes(for: date, at: coordinate) {
-    moonTimes = weatherTimes      // WeatherKit succeeded
-    usingWeatherKit = true        // triggers the attribution mark
+private var phaseData: MoonPhaseData {
+    let data = MoonPhaseCalculator.calculatePhase(for: selectedDate)
+    if let wk = wkMoon { return data.applyingWeatherKit(wk) }
+    return data // local fallback (offline / out of range / not entitled)
 }
+
+// Fetched in a .task keyed on the date + resolved location:
+wkMoon = await weatherMoon.moon(for: selectedDate, at: locationManager.coordinate)
 ```
 
-The user's location comes from the existing
+Illumination and the next-phase countdown always come from the local calculation
+(WeatherKit provides neither). Moonrise/moonset use `wkMoon` when present, otherwise
+`MoonPhaseCalculator.calculateMoonTimes`. The location comes from the existing
 [`LocationManager`](Architecture.md#locationmanager-observable-object); if location is
-unavailable it falls back to a default coordinate.
+unavailable it falls back to a default coordinate. The calendar grid and timeline are
+not overridden — they always use the local calculation.
 
 ## Attribution (required)
 
@@ -149,16 +163,17 @@ category `WeatherKit`). A repeated JWT error such as:
 ```
 
 means the App ID is not yet authorized for WeatherKit (service not enabled or not yet
-propagated). Success logs `WeatherKit moon times: rise ..., set ...` and the Apple
+propagated). Success logs `WeatherKit moon: phase ..., rise ..., set ...` and the Apple
 Weather attribution mark appears.
 
 ## Behavior summary
 
-| Situation | Moonrise/Moonset shown | Attribution mark |
-|-----------|------------------------|------------------|
-| WeatherKit entitled, online, date in range | WeatherKit (location-accurate) | Shown |
-| Offline / not entitled / propagation pending | Local `MoonPhaseCalculator` | Hidden |
-| Date outside WeatherKit's ~10-day window | Local `MoonPhaseCalculator` | Hidden |
+| Situation | Phase shown | Moonrise/Moonset shown | Attribution mark |
+|-----------|-------------|------------------------|------------------|
+| WeatherKit available, crescent/gibbous/quarter day | WeatherKit label | WeatherKit (location-accurate) | Shown |
+| WeatherKit available, New/Full day | Instantaneous local (refined) | WeatherKit (location-accurate) | Shown |
+| Offline / not entitled / propagation pending | Local `MoonPhaseCalculator` | Local `MoonPhaseCalculator` | Hidden |
+| Date outside WeatherKit's ~10-day window | Local `MoonPhaseCalculator` | Local `MoonPhaseCalculator` | Hidden |
 
 ## Related documentation
 

--- a/llms.txt
+++ b/llms.txt
@@ -67,19 +67,28 @@ Uses synodic month calculation:
 - **Reference:** New Moon on January 6, 2000, 18:14 UTC
 - **Phase Value:** 0.0 (new) to 1.0 (cycle complete)
 
-### Phase to Emoji Mapping
+### Phase Source
+For the SELECTED date, the displayed phase name/emoji come from WeatherKit
+(`DayWeather.moon.phase`) when available, matching Apple Weather. WeatherKit's whole-day
+New/Full labels are refined with the instantaneous local phase (so a new-moon day past
+the exact instant reads as a crescent). The local calculation (below) is the fallback
+and is used for all calendar/timeline dates. See `docs/WeatherKit.md`.
+
+### Local Phase to Emoji Mapping (MoonPhaseCalculator.classify)
+Phase is computed from the exact timestamp (JD = timeIntervalSince1970/86400 + 2440587.5),
+reference new moon JD 2451550.26. New/Full/Quarter use narrow (~1 day) windows:
 ```swift
-0.00-0.05: 🌑 New Moon
-0.05-0.20: 🌒 Waxing Crescent
-0.20-0.30: 🌓 First Quarter
-0.30-0.45: 🌔 Waxing Gibbous
-0.45-0.55: 🌕 Full Moon
-0.55-0.70: 🌖 Waning Gibbous
-0.70-0.80: 🌗 Last Quarter
-0.80-1.00: 🌘 Waning Crescent
+0.00-0.02 & 0.98-1.00: 🌑 New Moon
+0.02-0.23:             🌒 Waxing Crescent
+0.23-0.27:             🌓 First Quarter
+0.27-0.48:             🌔 Waxing Gibbous
+0.48-0.52:             🌕 Full Moon
+0.52-0.73:             🌖 Waning Gibbous
+0.73-0.77:             🌗 Last Quarter
+0.77-0.98:             🌘 Waning Crescent
 ```
 
-### Illumination Calculation
+### Illumination Calculation (always local)
 ```
 illumination = (1 - cos(phase * 2π)) / 2 * 100%
 ```


### PR DESCRIPTION
Follow-up to #5. Makes the displayed moon phase match Apple Weather.

## Why
The app showed "New Moon 🌑" for a date Apple Weather labeled "Waxing Crescent." Two causes: (1) the phase was computed locally, not from WeatherKit; (2) the local calculation snapped to midnight and used a linear illumination approximation, so it landed on the wrong side of the new-moon boundary.

## Changes
- **WeatherKit phase for the selected date** — `WeatherMoonService.moon(for:at:)` now returns `DayWeather.moon.phase` (the same data Apple Weather shows), applied via `MoonPhaseData.applyingWeatherKit(_:)` in `ContentView`, `PhaseInfoPanel`, and `ArrakisMoonView`.
- **New/Full refinement** — WeatherKit's `MoonPhase` is a whole-day label (it calls the entire new-moon day "New Moon"). On New/Full days the app keeps the instantaneous local phase, so a new-moon day past the exact instant reads as a crescent — matching Apple Weather's live headline.
- **Improved local fallback** — Julian Date derived from the exact timestamp (not midnight), corrected reference instant (JD 2451550.26), cosine illumination (matching the docs), and ~1-day New/Full/Quarter label windows.
- **Docs** — updated WeatherKit, MoonPhaseCalculation, Architecture, README, and llms.

Illumination and the next-phase countdown remain local (WeatherKit provides neither); calendar/timeline stay local. Moonrise/moonset and attribution are unchanged from #5.

## Verification
Confirmed on the iOS 27 simulator (WeatherKit working, returning a New-Moon day): the app correctly displays **Waxing Crescent 🌒**, keeps WeatherKit moonrise/moonset, and shows the Apple Weather attribution mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)